### PR TITLE
Check if manager is None instead of Falsy

### DIFF
--- a/autoslug/utils.py
+++ b/autoslug/utils.py
@@ -61,7 +61,7 @@ def generate_unique_slug(field, instance, slug, manager):
 
     index = 1
 
-    if not manager:
+    if manager is None:
         manager = field.model._default_manager
 
 


### PR DESCRIPTION
A custom defined manager will be overridden by the `_default_manager` when the custom manager returns `QuerySet<[]>`, because `bool(QuerySet<[]>) is False`